### PR TITLE
Publish to Nuget with Trusted Publishing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      id-token: write
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Replaced the disabled push step with a NuGet login step and updated the push command to use the login output.

See https://learn.microsoft.com/en-us/nuget/nuget-org/trusted-publishing